### PR TITLE
Corrected install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 All software for the 2018 UWRT Mars Rover
 
 
-To get all required dependencies, navigate to the project Workspace directory and run: 
+To get all required dependencies, navigate to the project root directory and run: 
 ```
+cd Workspace
 wstool init ../ dependencies.rosinstall
 rosdep install --from-paths src --ignore-src -r -y
 ```

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 All software for the 2018 UWRT Mars Rover
 
 
-To get all required dependencies, navigate to the project root directory and run: 
+To get all required dependencies, navigate to the project Workspace directory and run: 
 ```
-wstool init . dependencies.rosinstall
+wstool init ../ dependencies.rosinstall
 rosdep install --from-paths src --ignore-src -r -y
 ```
 Put all future dependencies in the dependencies.rosinstall file

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 All software for the 2018 UWRT Mars Rover
 
 
-To get all required dependencies, run: 
+To get all required dependencies, navigate to the project root directory and run: 
 ```
-rosinstall dependencies.rosinstall
+wstool init . dependencies.rosinstall
 rosdep install --from-paths src --ignore-src -r -y
 ```
 Put all future dependencies in the dependencies.rosinstall file


### PR DESCRIPTION
`rosinstall dependencies.rosinstall` doesn't actually work, `wstool init` should properly download all necessary projects from the rosinstall. 